### PR TITLE
Image formats

### DIFF
--- a/pdf_diff/command_line.py
+++ b/pdf_diff/command_line.py
@@ -443,14 +443,14 @@ def main():
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument('files', nargs='*', # Use '*' to allow --changes with zero files
                         help='calculate differences between the two named files')
-    parser.add_argument('--changes', action='store_true', default=False, 
+    parser.add_argument('-c', '--changes', action='store_true', default=False, 
                         help='read change description from standard input, ignoring files')
-    parser.add_argument('--style', metavar='box|strike|underline,box|stroke|underline', 
+    parser.add_argument('-s', '--style', metavar='box|strike|underline,box|stroke|underline', 
                         default='strike,underline',
                         help='how to mark the differences in the two files (default: strike, underline)')
-    parser.add_argument('--format', choices=['png','gif','jpeg','ppm','tiff'], default='png',
+    parser.add_argument('-f', '--format', choices=['png','gif','jpeg','ppm','tiff'], default='png',
                         help='output format in which to render (default: png)')
-    parser.add_argument('--top-margin', metavar='margin', default=0., type=float,
+    parser.add_argument('-t', '--top-margin', metavar='margin', default=0., type=float,
                         help='TODO (default 0.0)')
     args = parser.parse_args()
 

--- a/pdf_diff/command_line.py
+++ b/pdf_diff/command_line.py
@@ -448,6 +448,8 @@ def main():
     parser.add_argument('--style', metavar='box|strike|underline,box|stroke|underline', 
                         default='strike,underline',
                         help='How to mark the differences in the two files (default: strike, underline)')
+    parser.add_argument('--format', choices=['png','gif','jpeg','ppm','tiff'], default='png',
+                        help='Output format in which to render (default: png)')
     parser.add_argument('--top-margin', metavar='margin', default=0., type=float,
                         help='TODO (default 0.0)')
     args = parser.parse_args()
@@ -473,7 +475,7 @@ def main():
     if args.changes:
         # to just do the rendering part
         img = render_changes(json.load(sys.stdin), style)
-        img.save(sys.stdout.buffer, "PNG")
+        img.save(sys.stdout.buffer, args.format.upper())
         sys.exit(0)
 
     # Ensure enough file are specified
@@ -484,7 +486,7 @@ def main():
 
     changes = compute_changes(args.files[0], args.files[1], top_margin=float(args.top_margin))
     img = render_changes(changes, style)
-    img.save(sys.stdout.buffer, "PNG")
+    img.save(sys.stdout.buffer, args.format.upper())
 
 
 if __name__ == "__main__":

--- a/pdf_diff/command_line.py
+++ b/pdf_diff/command_line.py
@@ -442,14 +442,14 @@ def main():
                    'side-by-side images with the differences marked (in PNG format).')
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument('files', nargs='*', # Use '*' to allow --changes with zero files
-                        help='Calculate differences between the two named files')
+                        help='calculate differences between the two named files')
     parser.add_argument('--changes', action='store_true', default=False, 
-                        help='Read change description from standard input, ignoring files')
+                        help='read change description from standard input, ignoring files')
     parser.add_argument('--style', metavar='box|strike|underline,box|stroke|underline', 
                         default='strike,underline',
-                        help='How to mark the differences in the two files (default: strike, underline)')
+                        help='how to mark the differences in the two files (default: strike, underline)')
     parser.add_argument('--format', choices=['png','gif','jpeg','ppm','tiff'], default='png',
-                        help='Output format in which to render (default: png)')
+                        help='output format in which to render (default: png)')
     parser.add_argument('--top-margin', metavar='margin', default=0., type=float,
                         help='TODO (default 0.0)')
     args = parser.parse_args()


### PR DESCRIPTION
Fairly straightforward PR:
- Use of argparse from previous PR easily allows addition of other supported image formats via PIL;
- (minor) : use lower case for start of help text for uniformity with '-h' option;
- Add short forms for each command-line option. 