### PR TITLE
Useability changes (python3 check, import removal, stderr usage)

### DIFF
--- a/pdf_diff/command_line.py
+++ b/pdf_diff/command_line.py
@@ -10,8 +10,6 @@ import json, subprocess, io, os
 from lxml import etree
 from PIL import Image, ImageDraw, ImageOps
 
-from six import int2byte
-
 def compute_changes(pdf_fn_1, pdf_fn_2, top_margin=0):
     # Serialize the text in the two PDFs.
     docs = [serialize_pdf(0, pdf_fn_1, top_margin), serialize_pdf(1, pdf_fn_2, top_margin)]

--- a/pdf_diff/command_line.py
+++ b/pdf_diff/command_line.py
@@ -3,8 +3,7 @@
 import sys
 
 if sys.version_info[0] < 3:
-    print("ERROR: Python version 3+ is required.")
-    sys.exit(1)
+    sys.exit("ERROR: Python version 3+ is required.")
 
 import json, subprocess, io, os
 from lxml import etree
@@ -459,8 +458,8 @@ def main():
     args = parser.parse_args()
 
     def invalid_usage(msg):
-        print('ERROR: %s' % (msg))
-        parser.print_usage()
+        sys.stderr.write('ERROR: %s%s' % (msg, os.linesep))
+        parser.print_usage(sys.stderr)
         sys.exit(1)
 
     # Validate style

--- a/pdf_diff/command_line.py
+++ b/pdf_diff/command_line.py
@@ -1,6 +1,12 @@
 #!/usr/bin/python3
 
-import sys, json, subprocess, io, os
+import sys
+
+if sys.version_info[0] < 3:
+    print("ERROR: Python version 3+ is required.")
+    sys.exit(1)
+
+import json, subprocess, io, os
 from lxml import etree
 from PIL import Image, ImageDraw, ImageOps
 


### PR DESCRIPTION
A few small changes in one PR:
* Following from the problems @wookayin ran across in #12, added an explicit check for python 3;
* Removed the accidental import in one of my earlier commits;
* Redirect errors to stderr, so they are visible even when redirecting stdout to a file.

Hopefully they should all be pretty straightforward.