### PR TITLE
Skip non-text elements during pdf serialization.

### DIFF
--- a/pdf_diff/command_line.py
+++ b/pdf_diff/command_line.py
@@ -27,6 +27,9 @@ def serialize_pdf(i, fn, top_margin, bottom_margin):
     text = []
     textlength = 0
     for run in box_generator:
+        if run["text"] is None:
+            continue
+
         normalized_text = run["text"].strip()
 
         # Ensure that each run ends with a space, since pdftotext


### PR DESCRIPTION
Add skipping of non-text elements during pdf serialization, since they led to AttributeError during text extraction - problem was mentioned in #19 