### PR TITLE
Fix unterminated string literal in argument

### DIFF
--- a/pdf_diff/command_line.py
+++ b/pdf_diff/command_line.py
@@ -453,8 +453,7 @@ def main():
                         help='calculate differences between the two named files')
     parser.add_argument('-c', '--changes', action='store_true', default=False, 
                         help='read change description from standard input, ignoring files')
-    parser.add_argument('-s', '--style
-                        ', metavar='box|strike|underline,box|stroke|underline', 
+    parser.add_argument('-s', '--style', metavar='box|strike|underline,box|stroke|underline', 
                         default='strike,underline',
                         help='how to mark the differences in the two files (default: strike, underline)')
     parser.add_argument('-f', '--format', choices=['png','gif','jpeg','ppm','tiff'], default='png',


### PR DESCRIPTION
### Description:
- Fixed an unterminated string literal in the `--style` argument.
- Removed unnecessary line breaks that were preventing the program from running correctly.

### Why:
- The unterminated string caused a syntax error, making the program fail to execute.
